### PR TITLE
Remove obfuscation in request method when an exception occurs

### DIFF
--- a/lib/Signaturit/Client.php
+++ b/lib/Signaturit/Client.php
@@ -841,19 +841,16 @@ class Client
      * @param $path
      * @param array $params
      * @param bool $json
+     * @throws \Exception
      *
      * @return \Psr\Http\Message\ResponseInterface
      */
     protected function request($method, $path, $params = [], $json = true)
     {
-        try {
-            $response = $this->client->$method("$this->url/$path", $params)->getBody();
+        $response = $this->client->$method("$this->url/$path", $params)->getBody();
 
-            if ($json) {
-                $response = json_decode($response, true);
-            }
-        } catch (\Exception $exception) {
-            $response = $exception->getMessage();
+        if ($json) {
+            $response = json_decode($response, true);
         }
 
         return $response;


### PR DESCRIPTION
In my opinion, exceptions should be handled by the applications that are using the sdk. If they are handled and the client just returns a plain string it's pretty ugly to check if there have been errors, so it would be better to just throw the Guzzle exception as it is.